### PR TITLE
chore: drop support for Node 6-10 and remove 50 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Textwrap for javascript/nodejs. Correctly handles wide characters (宽字符) and emojis (😃). Wraps strings with option to break on words.",
   "main": "src/main.js",
   "engines": {
-    "node": ">=6"
+    "node": ">=12"
   },
   "bin": {
     "smartwrap": "src/terminal-adapter.js"
@@ -25,7 +25,6 @@
   "author": "tecfu",
   "license": "MIT",
   "dependencies": {
-    "array.prototype.flat": "^1.2.3",
     "breakword": "^1.0.5",
     "grapheme-splitter": "^1.0.4",
     "strip-ansi": "^6.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,6 @@
 const breakword = require("breakword")
 const stripansi = require("strip-ansi")
 const wcwidth = require("wcwidth")
-const flat = require("array.prototype.flat")
-if (!Array.prototype.flat) flat.shim()
 
 const ANSIPattern = [
   "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",


### PR DESCRIPTION
closes https://github.com/tecfu/smartwrap/issues/17

Node 10 support ended May 19, 2020 and `array.prototype.flat` is responsible for most of this project's dependencies: https://npmgraph.js.org/?q=smartwrap

If a user really wants to use a long EOL version of Node they could polyfill `array.prototype.flat` themselves rather than sticking all users with those dependencies